### PR TITLE
Delete unused variables

### DIFF
--- a/src/html/tbk-mall-normal.php
+++ b/src/html/tbk-mall-normal.php
@@ -36,14 +36,12 @@ switch ($action) {
             [
                 "storeCode" => "597044444402",
                 "amount" => 1200,
-                "buyOrder" => rand(),
-                "sessionId" => $sessionId
+                "buyOrder" => rand()
             ],
             [
                 "storeCode" => "597044444403",
                 "amount" => 2500,
-                "buyOrder" => rand(),
-                "sessionId" => $sessionId
+                "buyOrder" => rand()
             ]
         ];
 


### PR DESCRIPTION
Remove "sessionId" variable inside stores data because it is not a parameter. It is defined outside stores data.